### PR TITLE
Feat/40 rebrand

### DIFF
--- a/Theme.ts
+++ b/Theme.ts
@@ -6,7 +6,6 @@ export const AppTheme: DefaultTheme = {
     // Brand Colours
     cream: '#f9f2ec',
     plum: '#532b3a',
-    turquoise: '#57b6b2',
     teal: '#025157',
     pink: '#ffb1b8',
 

--- a/Theme.ts
+++ b/Theme.ts
@@ -7,12 +7,10 @@ export const AppTheme: DefaultTheme = {
     cream: '#f9f2ec',
     plum: '#532b3a',
     turquoise: '#57b6b2',
-    turquoise_dark: '#095157',
     teal: '#025157',
     pink: '#ffb1b8',
 
     // Secondary colours
-    blue: '#425cc7',
     orange: '#ff7f30',
 
     white: '#ffffff',
@@ -128,7 +126,7 @@ export const GlobalStyle = createGlobalStyle`
   }
 
   h1, h2, h3, h4, h5, h6 {
-    color: ${(props) => props.theme.colours.teal};
+    color: ${(props) => props.theme.colours.plum};
     font-size: 100%;
     font-style: normal;
     font-weight: bold;

--- a/components/ArtistModal.tsx
+++ b/components/ArtistModal.tsx
@@ -111,7 +111,7 @@ const SpeechBubble = styled.div`
   }
 
   button {
-    background-color: ${(props) => props.theme.colours.blue};
+    background-color: ${(props) => props.theme.colours.teal};
     border: none;
     bottom: -1.5rem;
     color: ${(props) => props.theme.colours.white};

--- a/components/ColourCheckbox.tsx
+++ b/components/ColourCheckbox.tsx
@@ -27,7 +27,7 @@ const Input = styled.input`
   border: 0;
 
   &:focus ~ ${Swatch} {
-    outline: 2px dashed ${(props) => props.theme.colours.blue};
+    outline: 2px dashed ${(props) => props.theme.colours.teal};
     outline-offset: 4px;
   }
 

--- a/components/ImageHeader.tsx
+++ b/components/ImageHeader.tsx
@@ -13,8 +13,7 @@ interface HeaderProps {
 const Header = styled.header`
   ${Section}
   background-color: ${(props) => props.theme.colours.teal};
-  border-top: 1rem solid ${(props) => props.theme.colours.turquoise};
-  height: 5rem;
+  height: 6rem;
 
   ${Container} {
     display: flex;
@@ -40,9 +39,10 @@ const Header = styled.header`
   }
 
   button {
-    background-color: ${(props) => props.theme.colours.blue};
+    background-color: ${(props) => props.theme.colours.turquoise};
     border: none;
-    color: ${(props) => props.theme.colours.white};
+    color: ${(props) => props.theme.colours.plum};
+    cursor: pointer;
     font-weight: bold;
     padding: 0.3rem 0.6rem;
   }

--- a/components/ImageHeader.tsx
+++ b/components/ImageHeader.tsx
@@ -39,7 +39,7 @@ const Header = styled.header`
   }
 
   button {
-    background-color: ${(props) => props.theme.colours.turquoise};
+    background-color: ${(props) => props.theme.colours.cream};
     border: none;
     color: ${(props) => props.theme.colours.plum};
     cursor: pointer;

--- a/components/ImageLink.tsx
+++ b/components/ImageLink.tsx
@@ -24,7 +24,7 @@ const FlexLink = styled.a`
 
   div {
     color: ${(props) => props.theme.colours.cream};
-    background-color: ${(props) => props.theme.colours.blue};
+    background-color: ${(props) => props.theme.colours.teal};
   }
 `;
 

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
  */
 export const Page = styled.div`
   align-items: center;
-  background-color: ${(props) => props.theme.colours.white};
+  background-color: ${(props) => props.theme.colours.pink};
   display: flex;
   flex-direction: column;
   min-height: 100vh;

--- a/components/SaveModal.tsx
+++ b/components/SaveModal.tsx
@@ -42,7 +42,7 @@ const Controls = styled.div`
   flex-direction: column;
 
   button {
-    background-color: ${(props) => props.theme.colours.blue};
+    background-color: ${(props) => props.theme.colours.teal};
     border: none;
     color: ${(props) => props.theme.colours.white};
     font-weight: bold;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,8 +12,7 @@ import { ImageData } from '../types';
 const Header = styled.header`
   ${Section}
   background-color: ${(props) => props.theme.colours.teal};
-  flex-basis: 8rem;
-  border-top: 1rem solid ${(props) => props.theme.colours.turquoise};
+  flex-basis: 10rem;
 
   ${Container} {
     display: flex;
@@ -102,7 +101,7 @@ const HowToPlay = styled.div`
 
 const Footer = styled.footer`
   ${Section}
-  background-color: ${(props) => props.theme.colours.teal};
+  background-color: ${(props) => props.theme.colours.plum};
   height: 4rem;
 
   a {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -66,15 +66,23 @@ const ImageList = styled.ul`
   width: 100%;
 
   li {
+    border: 3px solid;
+    border-width: min(6vh,8vw);
+    border-image-source: url(frame.svg);
+    border-image-slice: 12%;
     margin: 1rem 0;
-    width: 100%;
+    width: 95%;
 
     ${(props) => props.theme.screenSizes.tabletPortraitPlus} {
-      width: calc(100% / 2);
+      width: calc(95% / 2);
     }
 
     ${(props) => props.theme.screenSizes.tabletLandscapePlus} {
-      width: calc(100% / 3);
+      width: calc(95% / 3);
+    }
+
+    a {
+      margin: 0;
     }
   }
 `;

--- a/pages/palette/[id].tsx
+++ b/pages/palette/[id].tsx
@@ -43,8 +43,11 @@ const Instructions = styled.legend`
 
 const LayoutSwitch = styled.div`
   align-items: center;
+  background-color: ${(props) => props.theme.colours.white};
+  border-radius: 0.5rem;
   display: flex;
   flex-direction: column;
+  padding: 1rem;
 
   ${(props) => props.theme.screenSizes.tabletPortraitPlus} {
     align-items: flex-start;
@@ -88,7 +91,7 @@ const Swatch = styled.div<{ bgCol: Colour }>`
 `;
 
 const StartLink = styled.a`
-  background-color: ${(props) => props.theme.colours.blue};
+  background-color: ${(props) => props.theme.colours.teal};
   border: none;
   color: ${(props) => props.theme.colours.white};
   cursor: pointer;

--- a/styled.d.ts
+++ b/styled.d.ts
@@ -5,7 +5,6 @@ declare module 'styled-components' {
     colours: {
       cream: string;
       plum: string;
-      turquoise: string;
       teal: string;
       pink: string;
 

--- a/styled.d.ts
+++ b/styled.d.ts
@@ -6,11 +6,9 @@ declare module 'styled-components' {
       cream: string;
       plum: string;
       turquoise: string;
-      turquoise_dark: string;
       teal: string;
       pink: string;
 
-      blue: string;
       orange: string;
 
       white: string;


### PR DESCRIPTION
Closes #40 

- Remove blue from theme
- Use Pink for background
- Add frames to chooser

## Notes

- Frames are not perfect - and might look better with cream rather than orange bg
- Not sure about the tuquoise button as a one off, but plum not great in that header
