### PR TITLE
Testing fixes

### DIFF
--- a/components/ColourButton.tsx
+++ b/components/ColourButton.tsx
@@ -11,18 +11,19 @@ interface colourButtonProps {
 }
 
 const Button = styled.button`
-  padding: 0;
-  border: 1px solid ${(props) => props.theme.colours.grey};
-  border-radius: 0.5rem;
   align-items: center;
+  aspect-ratio: 1;
+  border-radius: 0.5rem;
+  border: 0;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  overflow: hidden;
-  aspect-ratio: 1;
   margin: 5px;
   min-height: 44px;
   min-width: 44px;
+  outline: 1px solid ${(props) => props.theme.colours.grey};
+  overflow: hidden;
+  padding: 0;
   width: calc(20% - 10px);
 
   ${(props) => props.theme.screenSizes.tabletPortraitPlus} {
@@ -37,7 +38,7 @@ const Swatch = styled.div<{ bgCol: Colour; active: Boolean }>`
   border-radius: 0.5rem;
   ${(props) =>
     props.active
-      ? `border: 3px solid ${props.theme.colours.grey}`
+      ? `border: 5px solid ${props.theme.colours.grey}; box-shadow: inset 0px 0px 0 2px ${props.theme.colours.white};`
       : `border: 3px solid transparent`}
 `;
 

--- a/components/PaletteControl.tsx
+++ b/components/PaletteControl.tsx
@@ -11,32 +11,32 @@ interface paletteControlProps {
 
 const defaultPalette: Palette = [
   {
-    name: 'red',
-    value: '#EF4444',
+    name: 'RED 7',
+    value: '#f03e3e',
   },
   {
-    name: 'blue',
-    value: '#3B82F6',
+    name: 'BLUE 7',
+    value: '#1c7ed6',
   },
   {
-    name: 'yellow',
-    value: '#FBBF24',
+    name: 'YELLOW 7',
+    value: '#f59f00',
   },
   {
-    name: 'green',
-    value: '#10B981',
+    name: 'GREEN 7',
+    value: '#37b24d',
   },
   {
-    name: 'orange',
-    value: '#FF922B',
+    name: 'ORANGE 7',
+    value: '#f76707',
   },
   {
-    name: 'purple',
-    value: '#8B5CF6',
+    name: 'VIOLET 7',
+    value: '#7048e8',
   },
   {
-    name: 'grey',
-    value: '#343a40',
+    name: 'GRAY 7',
+    value: '#495057',
   },
   {
     name: 'white',
@@ -71,7 +71,7 @@ export const PaletteControl = ({
   change,
 }: paletteControlProps) => {
   // if we have a palette, spread white into it, otherwise give the default
-  const currentPalette = palette
+  const currentPalette = palette?.length
     ? [
         ...palette,
         ...[

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,17 +15,22 @@ const Header = styled.header`
   flex-basis: 8rem;
   border-top: 1rem solid ${(props) => props.theme.colours.turquoise};
 
-  ${Container} {
+  div {
+    align-items: center;
     display: flex;
     justify-content: space-between;
   }
 
   a {
-    align-self: end;
     color: ${(props) => props.theme.colours.cream};
-    font-size: 2rem;
+    flex: 0;
+    font-size: 1.5rem;
     text-decoration: none;
     vertical-align: middle;
+
+    ${(props) => props.theme.screenSizes.tabletPortraitPlus} {
+      font-size: 2rem;
+    }
 
     &:focus {
       outline: 3px solid ${(props) => props.theme.colours.orange};


### PR DESCRIPTION
Some small changes for bugs found in my own testing

- The palette is initialised to an empty array so is always truthy, preventing use of default palette if you skipped the palette page somehow. Now checking for its length instead
- Game palette button styling borrowed from palette checkboxes, which have better visibility for if they are selected
- The header was a bit broken on mobile due to wrongly nested styling, which should be fixed